### PR TITLE
Add simple model to display lahug and pathway shapefiles

### DIFF
--- a/models/display_two_shapefiles.gaml
+++ b/models/display_two_shapefiles.gaml
@@ -1,0 +1,38 @@
+/**
+ * Display two shapefiles: lahug.shp and pathway.shp
+ * Minimal example for viewing GIS data.
+ */
+
+model simple_display
+
+global {
+    file lahug_file <- file("../includes/lahug.shp");
+    file pathway_file <- file("../includes/pathway.shp");
+    geometry shape <- envelope(lahug_file) + envelope(pathway_file);
+
+    init {
+        create building from: lahug_file;
+        create pathway from: pathway_file;
+    }
+}
+
+species building {
+    aspect default {
+        draw shape color: #gray border: #black;
+    }
+}
+
+species pathway {
+    aspect default {
+        draw shape color: #blue width: 2;
+    }
+}
+
+experiment main type: gui {
+    output {
+        display map {
+            species building aspect: default;
+            species pathway aspect: default;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `display_two_shapefiles.gaml` to show `lahug.shp` and `pathway.shp`

## Testing
- `git status --short`